### PR TITLE
feat: make NM_REMOTE_APP_LOG_DIR_APP_DIR_PERMISSIONS configured

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -1699,6 +1699,13 @@ public class YarnConfiguration extends Configuration {
   public static final String NM_REMOTE_APP_LOG_DIR_GROUPNAME =
       NM_PREFIX + "remote-app-log-dir.groupname";
 
+  /**
+   * Specifies the permissions for the application log directory
+   * under the remote app log dir.
+   */
+  public static final String NM_REMOTE_APP_LOG_DIR_APP_DIR_PERMISSIONS =
+      NM_PREFIX + "remote-app-log-dir.app-dir.permissions";
+
   public static final String YARN_LOG_SERVER_URL =
     YARN_PREFIX + "log.server.url";
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/LogAggregationFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/LogAggregationFileController.java
@@ -113,6 +113,12 @@ public abstract class LogAggregationFileController {
 
   protected boolean fsSupportsChmod = true;
 
+  /**
+   * Permissions for the Application directory.
+   * This can be configured via yarn.nodemanager.remote-app-log-dir.app-dir.permissions.
+   */
+  protected FsPermission appDirPermissions;
+
   private static class FsLogPathKey {
     private Class<? extends FileSystem> fsType;
     private Path logPath;
@@ -166,6 +172,7 @@ public abstract class LogAggregationFileController {
 
     extractRemoteRootLogDir();
     extractRemoteRootLogDirSuffix();
+    initAppDirPermissions();
 
     initInternal(conf);
   }
@@ -374,6 +381,43 @@ public abstract class LogAggregationFileController {
   }
 
   /**
+   * Initialize the app dir permissions from configuration.
+   * If not configured, use the default value (770).
+   */
+  private void initAppDirPermissions() {
+    String permKey = String.format(
+        YarnConfiguration.LOG_AGGREGATION_REMOTE_APP_LOG_DIR_FMT,
+        fileControllerName)
+        + ".app-dir.permissions";
+    String permStr = conf.get(permKey);
+    if (permStr == null || permStr.isEmpty()) {
+      permStr = conf.get(
+          YarnConfiguration.NM_REMOTE_APP_LOG_DIR_APP_DIR_PERMISSIONS);
+    }
+    if (permStr == null || permStr.isEmpty()) {
+      /// Use default value: 0770
+      this.appDirPermissions = APP_DIR_PERMISSIONS;
+    } else {
+      try {
+        // Parse the permission string (e.g., "770", "777", "1777")
+        short perm = 0;
+        if (permStr.startsWith("0")) {
+          // Octal format like "0770"
+          perm = Short.parseShort(permStr.substring(1), 8);
+        } else {
+          // Decimal format like "770"
+          perm = Short.parseShort(permStr, 8);
+        }
+        this.appDirPermissions = FsPermission.createImmutable(perm);
+      } catch (NumberFormatException e) {
+        LOG.warn("Invalid permission '{}' for app dir, using default: {}",
+            permStr, APP_DIR_PERMISSIONS);
+        this.appDirPermissions = APP_DIR_PERMISSIONS;
+      }
+    }
+  }
+
+  /**
    * Verify and create the remote log directory.
    */
   public void verifyAndCreateRemoteLogDir() {
@@ -520,7 +564,7 @@ public abstract class LogAggregationFileController {
             LinkedList<Path> pathsToCreate = new LinkedList<>();
 
             while (!curDir.equals(rootLogDir)) {
-              if (!checkExists(remoteFS, curDir, APP_DIR_PERMISSIONS)) {
+              if (!checkExists(remoteFS, curDir, appDirPermissions)) {
                 pathsToCreate.addFirst(curDir);
                 curDir = curDir.getParent();
               } else {
@@ -529,7 +573,7 @@ public abstract class LogAggregationFileController {
             }
 
             for (Path path : pathsToCreate) {
-              createDir(remoteFS, path, APP_DIR_PERMISSIONS);
+              createDir(remoteFS, path, appDirPermissions);
             }
           } catch (IOException e) {
             LOG.error("Failed to setup application log directory for "
@@ -573,8 +617,8 @@ public abstract class LogAggregationFileController {
     try {
       FileStatus appDirStatus = fs.getFileStatus(path);
       if (fsSupportsChmod) {
-        if (!APP_DIR_PERMISSIONS.equals(appDirStatus.getPermission())) {
-          fs.setPermission(path, APP_DIR_PERMISSIONS);
+        if (!appDirPermissions.equals(appDirStatus.getPermission())) {
+          fs.setPermission(path, appDirPermissions);
         }
       }
     } catch (FileNotFoundException fnfe) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -1714,6 +1714,18 @@
   </property>
 
   <property>
+    <description>The permissions for the application log directory
+    under the remote app log dir. The permissions can be specified
+    in octal format (e.g., "770", "777") or decimal format.
+    The default value is "770" which means only the owner and group
+    can access the directory. Set to "777" to allow all users to
+    access the application log directories.
+    </description>
+    <name>yarn.nodemanager.remote-app-log-dir.app-dir.permissions</name>
+    <value>770</value>
+  </property>
+
+  <property>
     <description>Generate additional logs about container launches.
     Currently, this creates a copy of the launch script and lists the
     directory contents of the container work dir. When listing directory

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/filecontroller/TestLogAggregationFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/filecontroller/TestLogAggregationFileController.java
@@ -192,4 +192,87 @@ public class TestLogAggregationFileController {
     verify(fs, times(1))
         .delete(argThat(new PathContainsString(".permission_check")), eq(false));
   }
+
+  @Test
+  void testAppDirPermissionsDefault() throws Exception {
+    Configuration conf = new Configuration();
+    LogAggregationFileController controller = mock(
+        LogAggregationFileController.class, Mockito.CALLS_REAL_METHODS);
+    FileSystem fs = mock(FileSystem.class);
+    doReturn(fs).when(controller).getFileSystem(any(Configuration.class));
+
+    controller.initialize(conf, "TFile");
+
+    // Default value should be 0770
+    FsPermission expected = FsPermission.createImmutable((short) 0770);
+    assertTrue(controller.appDirPermissions.equals(expected),
+        "Default app dir permissions should be 0770");
+  }
+
+  @Test
+  void testAppDirPermissionsOctalFormat() throws Exception {
+    Configuration conf = new Configuration();
+    conf.set(YarnConfiguration.NM_REMOTE_APP_LOG_DIR_APP_DIR_PERMISSIONS, "777");
+    LogAggregationFileController controller = mock(
+        LogAggregationFileController.class, Mockito.CALLS_REAL_METHODS);
+    FileSystem fs = mock(FileSystem.class);
+    doReturn(fs).when(controller).getFileSystem(any(Configuration.class));
+
+    controller.initialize(conf, "TFile");
+
+    FsPermission expected = FsPermission.createImmutable((short) 0777);
+    assertTrue(controller.appDirPermissions.equals(expected),
+        "App dir permissions should be 0777");
+  }
+
+  @Test
+  void testAppDirPermissionsOctalFormatWithLeadingZero() throws Exception {
+    Configuration conf = new Configuration();
+    conf.set(YarnConfiguration.NM_REMOTE_APP_LOG_DIR_APP_DIR_PERMISSIONS, "0777");
+    LogAggregationFileController controller = mock(
+        LogAggregationFileController.class, Mockito.CALLS_REAL_METHODS);
+    FileSystem fs = mock(FileSystem.class);
+    doReturn(fs).when(controller).getFileSystem(any(Configuration.class));
+
+    controller.initialize(conf, "TFile");
+
+    FsPermission expected = FsPermission.createImmutable((short) 0777);
+    assertTrue(controller.appDirPermissions.equals(expected),
+        "App dir permissions should be 0777");
+  }
+
+  @Test
+  void testAppDirPermissionsStickyBit() throws Exception {
+    Configuration conf = new Configuration();
+    conf.set(YarnConfiguration.NM_REMOTE_APP_LOG_DIR_APP_DIR_PERMISSIONS, "1777");
+    LogAggregationFileController controller = mock(
+        LogAggregationFileController.class, Mockito.CALLS_REAL_METHODS);
+    FileSystem fs = mock(FileSystem.class);
+    doReturn(fs).when(controller).getFileSystem(any(Configuration.class));
+
+    controller.initialize(conf, "TFile");
+
+    FsPermission expected = FsPermission.createImmutable((short) 01777);
+    assertTrue(controller.appDirPermissions.equals(expected),
+        "App dir permissions should be 01777 with sticky bit");
+  }
+
+  @Test
+  void testAppDirPermissionsInvalidValue() throws Exception {
+    FileSystem fs = mock(FileSystem.class);
+    doReturn(new URI("")).when(fs).getUri();
+
+    Configuration conf = new Configuration();
+    conf.set(YarnConfiguration.NM_REMOTE_APP_LOG_DIR_APP_DIR_PERMISSIONS, "invalid");
+    LogAggregationFileController controller = mock(
+        LogAggregationFileController.class, Mockito.CALLS_REAL_METHODS);
+    doReturn(fs).when(controller).getFileSystem(any(Configuration.class));
+
+    controller.initialize(conf, "TFile");
+
+    // Should fall back to default when invalid value is provided
+    FsPermission expected = FsPermission.createImmutable((short) 0770);
+    assertTrue(controller.appDirPermissions.equals(expected),
+        "Should fall back to default 0770 for invalid value");
+  }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

### AI Tooling

If an AI tool was used:

- [ ] The PR includes the phrase "Contains content generated by <tool>"
      where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy
      https://www.apache.org/legal/generative-tooling.html